### PR TITLE
Fordeler CUD-kostnader på prosjekter

### DIFF
--- a/views/cost_breakdown_excluding_nais.sql
+++ b/views/cost_breakdown_excluding_nais.sql
@@ -17,7 +17,7 @@
          , b.sku_description
          , (SUM(CAST(b.cost * 1000000 AS int64)) + SUM(IFNULL((
                                                                   SELECT
-                                                                      SUM(CAST(c.amount * 1000000 AS int64))
+                                                                      SUM(IF(c.type != 'COMMITTED_USAGE_DISCOUNT_DOLLAR_BASE', CAST(c.amount * 1000000 AS int64), 0))
                                                                   FROM
                                                                       UNNEST(credits) c),
                                                               0))) / 1000000
@@ -29,7 +29,10 @@
                        ON b.project_id = p.project_id
 
     WHERE b.project_id NOT IN ('nais-dev-2e7b', 'nais-labs-ebde', 'nais-prod-020f')
-       OR b.project_name IS NULL
+        OR b.project_name IS NULL
+        -- CUD som ikke fordeles på team. Inkluderes ved å ikke trekke fra CUD-credits i stedet
+        AND b.sku_id NOT IN ('08CF-4B12-9DDF', 'F61D-4D51-AAFC')
+
 
     GROUP BY project_name, env, team, cost_category, dato, service_description, sku_id, sku_description, app, tenant
 )

--- a/views/cost_breakdown_nais.sql
+++ b/views/cost_breakdown_nais.sql
@@ -60,13 +60,15 @@
                   , DATE(usage_start_time, 'US/Pacific') AS dato
                   , (SUM(CAST(cost * 1000000 AS int64)) + SUM(IFNULL((
                                                                          SELECT
-                                                                             SUM(CAST(c.amount * 1000000 AS int64))
+                                                                             SUM(IF(c.type != 'COMMITTED_USAGE_DISCOUNT_DOLLAR_BASE', CAST(c.amount * 1000000 AS int64), 0))
                                                                          FROM
                                                                              UNNEST(credits) c),
                                                                      0))) / 1000000 AS total
              FROM `nais-analyse-prod-2dcc.navbilling.gcp_billing_export`
                   -- kostnader for disse tre prosjektene skal særbehandles
              WHERE project_id IN ('nais-dev-2e7b', 'nais-labs-ebde', 'nais-prod-020f')
+                  -- CUD som ikke fordeles på team. Inkluderes ved å ikke trekke fra CUD-credits i stedet
+               AND sku_id NOT IN ('08CF-4B12-9DDF', 'F61D-4D51-AAFC')
              GROUP BY 1,2,3,4,5,6
          )
 


### PR DESCRIPTION
Kostnader beregnes som `sum( cost + credits )` hvor credits er et negativt tall som tilsvarer en rabatt. Noen credittyper har egne SKUer som legger til en cost som ikke registreres på teams, dette gjelder spesielt continued use discounts (CUD). Her er `sum( cost + credits )` typisk ≈0, mens den faktiske kostnaden havner i rader med `sku.description` `Commitment - dollar based v1: Cloud SQL database europe-north1 for 1 year` som altså ikke kan tillegnes de ulike teamprosjektene.

Løsningen på dette er å fjerne radene som ikke kan fordeles i tillegg til å la være å trekke fra CUD-credits i den totale kostnaden (se endring i view-definisjoner). 

Et annet problem er at for continued use discounts (CUD) er credits oppgitt i dollar i stedet for euro. Det betyr at `sum( cost + credits )` ikke gir riktig svar fordi `cost` og `credits` ikke er oppgitt i samme valuta. Heldigvis løses også dette problemet ved at vi ikke lenger trekker fra credits relatert til CUD.

Merk: Gammel utregning tok ikke hensyn til at CUD-credits er oppgitt i Dollar. Derfor avviker den nye summen noe (~100€ /uke) fra den gamle i perioden etter at CUD ble innført.