### PR TITLE
Bytte til kopi av nais-labs gke_usage

### DIFF
--- a/views/cost_breakdown_nais.sql
+++ b/views/cost_breakdown_nais.sql
@@ -35,7 +35,7 @@
                       , SUM(cost) AS sum_cost
                       , SUM(SUM(cost)) OVER (PARTITION BY sku_id, usage_start_time) AS sum_cost_per_sku
                       --,sum(cost_with_unallocated_untracked) as sum_cost_with_unallocated_untracked
-                 FROM `nais-labs-ebde.gke_usage.usage_metering_cost_breakdown`
+                 FROM `nais-io.legacy_gke_usage.nais-labs-ebde`
                  GROUP BY cluster, namespace, sku_id, usage_start_time, app
              ),
 


### PR DESCRIPTION
Da nais-labs ble slått av (tidlig i april 2023) mistet vi tabellen som ble brukt til å fordele gke-ressurser på team i labs-clusteret. Bytter til å bruke kopien som er lagret i nais-io, men den har bare data til morgenen 08.03.23. Dette kan gi litt rare utslag for perioden mellom 07.03.23 og at labs ble skrudd av.